### PR TITLE
feat: add functionality to upload and remove audio file

### DIFF
--- a/client/src/api/tracks.ts
+++ b/client/src/api/tracks.ts
@@ -35,3 +35,20 @@ export const updateTrack = async (
 export const deleteTrack = async (id: string): Promise<void> => {
   await axios.delete(`/api/tracks/${id}`);
 };
+
+export const uploadTrackFile = async (
+  id: string,
+  file: File
+): Promise<Track> => {
+  const form = new FormData();
+  form.append("file", file);
+  const { data } = await axios.post<Track>(`/api/tracks/${id}/upload`, form, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data;
+};
+
+export const deleteTrackFile = async (id: string): Promise<Track> => {
+  const { data } = await axios.delete<Track>(`/api/tracks/${id}/file`);
+  return data;
+};

--- a/client/src/components/Modal/DeleteConfirmationModal.tsx
+++ b/client/src/components/Modal/DeleteConfirmationModal.tsx
@@ -13,7 +13,7 @@ export function DeleteConfirmationModal({
 }: DeleteConfirmationModalProps) {
   return (
     <Modal onClose={onCancel} data-testid="confirm-dialog">
-      <h2 className="text-xl font-semibold mb-4">Delete “{title}”?</h2>
+      <h2 className="text-xl font-semibold mb-4">{title}</h2>
       <p className="mb-6">This action cannot be undone.</p>
       <div className="flex justify-end gap-2">
         <button

--- a/client/src/components/Modal/UploadFileModal.tsx
+++ b/client/src/components/Modal/UploadFileModal.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Modal } from "./index";
+import type { Track } from "@/types/track";
+
+interface UploadFileModalProps {
+  track: Track;
+  onUpload(file: File): Promise<void>;
+  onCancel(): void;
+}
+
+export function UploadFileModal({
+  track,
+  onUpload,
+  onCancel,
+}: UploadFileModalProps) {
+  const [error, setError] = React.useState<string>("");
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError("");
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      await onUpload(file);
+    } catch (err: any) {
+      setError(err.response?.data?.error || err.message);
+    }
+  };
+
+  return (
+    <Modal onClose={onCancel} data-testid="upload-dialog">
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">
+          Upload file for “{track.title}”
+        </h2>
+
+        <fieldset className="fieldset">
+          <legend className="fieldset-legend">Pick a file</legend>
+          <input
+            type="file"
+            accept="audio/*"
+            className="file-input"
+            data-testid="input-file"
+            onChange={handleChange}
+          />
+          <label className="label">
+            <span className="label-text">
+              MP3, WAV… max size enforced by server (10MB)
+            </span>
+          </label>
+          {error && (
+            <p className="text-error text-sm mt-1" data-testid="error-file">
+              {error}
+            </p>
+          )}
+        </fieldset>
+
+        <div className="flex justify-end">
+          <button
+            className="btn btn-outline"
+            onClick={onCancel}
+            data-testid="cancel-upload"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/TrackTable/columns.tsx
+++ b/client/src/components/TrackTable/columns.tsx
@@ -1,11 +1,13 @@
 import { ColumnDef } from "@tanstack/react-table";
 import BackupCoverUrl from "@/assets/logo.svg";
-import { Edit2, Trash2 } from "lucide-react";
+import { Edit2, Trash2, X } from "lucide-react";
 import type { Track } from "@/types/track";
 
 export const getColumns = (
   onEdit: (id: string) => void,
-  onDelete: (id: string) => void
+  onDelete: (id: string) => void,
+  onUploadClick: (id: string) => void,
+  onDeleteFile: (id: string) => void
 ): ColumnDef<Track>[] => [
   {
     accessorKey: "coverImage",
@@ -50,6 +52,35 @@ export const getColumns = (
       return (row.getValue<string[]>(id) ?? []).includes(filterValue);
     },
     cell: (info) => (info.getValue<string[]>() ?? []).join(", "),
+  },
+
+  {
+    id: "audio",
+    header: "Audio",
+    enableSorting: false,
+    size: 300,
+    cell: ({ row }) => {
+      const { id, audioFile } = row.original;
+      return audioFile ? (
+        <div className="relative flex items-center gap-2">
+          <audio
+            controls
+            src={`/api/files/${audioFile}`}
+            className="w-full max-w-xs mr-2"
+          />
+          <button
+            className="btn btn-xs btn-circle btn-error btn-ghost absolute top-0 right-0"
+            onClick={() => onDeleteFile(id)}
+          >
+            <X size={12}/>
+          </button>
+        </div>
+      ) : (
+        <button className="btn btn-xs" onClick={() => onUploadClick(id)}>
+          Upload
+        </button>
+      );
+    },
   },
 
   {

--- a/client/src/components/TrackTable/index.tsx
+++ b/client/src/components/TrackTable/index.tsx
@@ -35,6 +35,8 @@ interface Props {
   onSearchChange(v: string): void;
   onEdit(id: string): void;
   onDelete(id: string): void;
+  onUploadClick(id: string): void;
+  onDeleteFile(id: string): void;
 }
 
 export const TrackTable: React.FC<Props> = ({
@@ -58,6 +60,8 @@ export const TrackTable: React.FC<Props> = ({
   onSearchChange,
   onEdit,
   onDelete,
+  onUploadClick,
+  onDeleteFile,
 }) => {
   const [sorting, setSorting] = useState<SortingState>([
     { id: sort, desc: order === "desc" },
@@ -76,8 +80,8 @@ export const TrackTable: React.FC<Props> = ({
   }, [sorting, setSort, setOrder]);
 
   const columns = useMemo(
-    () => getColumns(onEdit, onDelete),
-    [onEdit, onDelete]
+    () => getColumns(onEdit, onDelete, onUploadClick, onDeleteFile),
+    [onEdit, onDelete, onUploadClick, onDeleteFile]
   );
 
   const table = useReactTable({
@@ -122,7 +126,7 @@ export const TrackTable: React.FC<Props> = ({
         </div>
       </div>
 
-      <table className="table w-full table-fixed">
+      <table className="table w-full table-auto">
         <thead>
           {table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,6 +1,7 @@
 export { TagSelector } from "./Form/TagSelector";
 export { Modal } from "./Modal";
 export { DeleteConfirmationModal } from "./Modal/DeleteConfirmationModal";
+export { UploadFileModal } from "./Modal/UploadFileModal";
 export { TrackForm } from "./TrackForm";
 export { TrackTable } from "./TrackTable";
 export { Logo, FilterSelect, SearchInput } from "./common";

--- a/client/src/types/track.ts
+++ b/client/src/types/track.ts
@@ -6,7 +6,7 @@ export interface Track {
   genres: string[];
   coverImage?: string;
   createdAt: string;
-  fileUrl?: string;
+  audioFile?: string;
 }
 
 export type TrackFormData = Omit<Track, "id" | "createdAt">;


### PR DESCRIPTION
- added uploadTrackFile and deleteTrackFile functions to the client API;
- created a new UploadFileModal component with file‐pick fieldset styling;
- simplify DeleteConfirmationModal title to be unquoted and shortened;
- extended TrackTable columns to include an “Audio” cell with upload/remove buttons;
- wired up onUploadClick and onDeleteFile handlers through TrackTable props;
- updated TracksPage to manage upload and delete‐file flows with new modals;
- introduced deletingFileTrack state and confirmation modal for audio removal;
- renamed fileUrl into audioFile in the Track type to match backend.