### PR TITLE
refactor(api): remove duplicated logic

### DIFF
--- a/client/src/api/artistService.ts
+++ b/client/src/api/artistService.ts
@@ -1,32 +1,9 @@
 import { BaseService } from "./baseService";
 import { IHttpClient } from "./httpClient";
 
-/**
- * Defines operations for fetching artist data.
- */
-export interface IArtistService {
-  /** Fetch all artist names. */
-  listArtists(): Promise<string[]>;
-  /** Fetch a single artist by ID. */
-  getArtistById(id: string): Promise<string>;
-}
-
-/**
- * Service handling artist‐related HTTP calls via BaseService.
- */
-export class ArtistService
-  extends BaseService<string>
-  implements IArtistService
-{
+export class ArtistService extends BaseService<string> {
+  protected static readonly resource = "artists";
   constructor(http: IHttpClient) {
-    super(http, "artists");
-  }
-
-  listArtists(): Promise<string[]> {
-    return this.list();
-  }
-
-  getArtistById(id: string): Promise<string> {
-    return this.getById(id);
+    super(http, ArtistService.resource);
   }
 }

--- a/client/src/api/baseService.ts
+++ b/client/src/api/baseService.ts
@@ -1,44 +1,45 @@
+import { ListParams } from "@/types";
 import { IHttpClient } from "./httpClient";
 
 /**
- * Generic CRUD service. T is the entity type; CreateDto describes input for create/update.
+ * Generic CRUD wrapper
  */
 export abstract class BaseService<T, CreateDto = Partial<T>> {
-  constructor(
+  protected constructor(
     protected readonly http: IHttpClient,
-    private readonly resource: string
+    protected readonly resource: string
   ) {}
 
   /**
-   * List all resources, with optional query params.
+   * GET /resource
    */
-  list(params?: Record<string, unknown>): Promise<T[]> {
+  list<P extends ListParams = ListParams>(params?: P): Promise<T[]> {
     return this.http.get<T[]>(`/api/${this.resource}`, { params });
   }
 
   /**
-   * Get single resource by ID.
+   * GET /resource/:id
    */
   getById(id: string): Promise<T> {
     return this.http.get<T>(`/api/${this.resource}/${id}`);
   }
 
   /**
-   * Create a new resource.
+   * POST /resource
    */
   create(dto: CreateDto): Promise<T> {
     return this.http.post<T>(`/api/${this.resource}`, dto);
   }
 
   /**
-   * Update an existing resource by ID.
+   * PUT /resource/:id
    */
   update(id: string, dto: CreateDto): Promise<T> {
     return this.http.put<T>(`/api/${this.resource}/${id}`, dto);
   }
 
   /**
-   * Delete a resource by ID.
+   * DELETE /resource/:id
    */
   delete(id: string): Promise<void> {
     return this.http.delete<void>(`/api/${this.resource}/${id}`);

--- a/client/src/api/genreService.ts
+++ b/client/src/api/genreService.ts
@@ -1,29 +1,9 @@
 import { BaseService } from "./baseService";
 import { IHttpClient } from "./httpClient";
 
-/**
- * Defines operations for fetching genre data.
- */
-export interface IGenreService {
-  /** Fetch all genre names. */
-  listGenres(): Promise<string[]>;
-  /** Fetch a single genre by ID. */
-  getGenreById(id: string): Promise<string>;
-}
-
-/**
- * Service handling genre‐related HTTP calls via BaseService.
- */
-export class GenreService extends BaseService<string> implements IGenreService {
+export class GenreService extends BaseService<string> {
+  protected static readonly resource = "genres";
   constructor(http: IHttpClient) {
-    super(http, "genres");
-  }
-
-  listGenres(): Promise<string[]> {
-    return this.list();
-  }
-
-  getGenreById(id: string): Promise<string> {
-    return this.getById(id);
+    super(http, GenreService.resource);
   }
 }

--- a/client/src/api/httpClient.ts
+++ b/client/src/api/httpClient.ts
@@ -1,60 +1,46 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
-/**
- * Abstraction for HTTP operations.
+/** 
+ * HTTP abstraction 
  */
 export interface IHttpClient {
-  get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
-  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
-  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
-  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  get<T>(url: string, cfg?: AxiosRequestConfig): Promise<T>;
+  post<T>(url: string, data?: unknown, cfg?: AxiosRequestConfig): Promise<T>;
+  put<T>(url: string, data?: unknown, cfg?: AxiosRequestConfig): Promise<T>;
+  delete<T>(url: string, cfg?: AxiosRequestConfig): Promise<T>;
 }
 
-/**
- * Axios-based implementation of IHttpClient.
+/** 
+ * Axios implementation 
  */
 export class AxiosHttpClient implements IHttpClient {
   constructor(private readonly axiosInstance: AxiosInstance = axios) {}
 
-  async get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response: AxiosResponse<T> = await this.axiosInstance.get<T>(
-      url,
-      config
-    );
-    return response.data;
+  async get<T>(url: string, cfg?: AxiosRequestConfig): Promise<T> {
+    const res: AxiosResponse<T> = await this.axiosInstance.get(url, cfg);
+    return res.data;
   }
 
   async post<T>(
     url: string,
     data?: unknown,
-    config?: AxiosRequestConfig
+    cfg?: AxiosRequestConfig
   ): Promise<T> {
-    const response: AxiosResponse<T> = await this.axiosInstance.post<T>(
-      url,
-      data,
-      config
-    );
-    return response.data;
+    const res: AxiosResponse<T> = await this.axiosInstance.post(url, data, cfg);
+    return res.data;
   }
 
   async put<T>(
     url: string,
     data?: unknown,
-    config?: AxiosRequestConfig
+    cfg?: AxiosRequestConfig
   ): Promise<T> {
-    const response: AxiosResponse<T> = await this.axiosInstance.put<T>(
-      url,
-      data,
-      config
-    );
-    return response.data;
+    const res: AxiosResponse<T> = await this.axiosInstance.put(url, data, cfg);
+    return res.data;
   }
 
-  async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response: AxiosResponse<T> = await this.axiosInstance.delete<T>(
-      url,
-      config
-    );
-    return response.data;
+  async delete<T>(url: string, cfg?: AxiosRequestConfig): Promise<T> {
+    const res: AxiosResponse<T> = await this.axiosInstance.delete(url, cfg);
+    return res.data;
   }
 }

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,10 +1,10 @@
 import { AxiosHttpClient } from "./httpClient";
-import { ArtistService, IArtistService } from "./artistService";
-import { GenreService, IGenreService } from "./genreService";
-import { TrackService, ITrackService } from "./trackService";
+import { ArtistService } from "./artistService";
+import { GenreService } from "./genreService";
+import { TrackService } from "./trackService";
 
-const httpClient = new AxiosHttpClient();
+const http = new AxiosHttpClient();
 
-export const artistService: IArtistService = new ArtistService(httpClient);
-export const genreService: IGenreService = new GenreService(httpClient);
-export const trackService: ITrackService = new TrackService(httpClient);
+export const artistService = new ArtistService(http);
+export const genreService = new GenreService(http);
+export const trackService = new TrackService(http);

--- a/client/src/api/trackService.ts
+++ b/client/src/api/trackService.ts
@@ -1,104 +1,76 @@
+import { BaseService } from "./baseService";
 import { IHttpClient } from "./httpClient";
-import { Track, TrackFormData, Meta } from "@/types/track";
+import { Track, TrackFormData, Paginated } from "@/types";
 
-/**
- * Defines all operations for Track resources.
- */
-export interface ITrackService {
-  /** Fetches paginated tracks, with optional filters/sorting. */
-  fetchTracks(
-    page?: number,
-    limit?: number,
-    sort?: keyof Track,
-    order?: "asc" | "desc",
-    genre?: string,
-    artist?: string,
-    search?: string
-  ): Promise<{ data: Track[]; meta: Meta }>;
-
-  /** Fetch a single track by ID. */
-  getTrackById(id: string): Promise<Track>;
-  /** Create a new track. */
-  createTrack(dto: TrackFormData): Promise<Track>;
-  /** Update an existing track. */
-  updateTrack(id: string, dto: TrackFormData): Promise<Track>;
-  /** Delete a track. */
-  deleteTrack(id: string): Promise<void>;
-
-  /** Upload an audio file for a track. */
-  uploadTrackFile(id: string, file: File): Promise<Track>;
-  /** Delete the audio file associated with a track. */
-  deleteTrackFile(id: string): Promise<Track>;
-
-  /** Bulk-delete multiple tracks. */
-  deleteMultipleTracks(
-    ids: string[]
-  ): Promise<{ success: string[]; failed: string[] }>;
+export interface FetchTracksOptions {
+  page?: number;
+  limit?: number;
+  sort?: keyof Track;
+  order?: "asc" | "desc";
+  genre?: string;
+  artist?: string;
+  search?: string;
 }
 
-/**
- * Service handling track‐related HTTP calls.
- */
-export class TrackService implements ITrackService {
-  constructor(private readonly http: IHttpClient) {}
+export class TrackService extends BaseService<Track, TrackFormData> {
+  protected static readonly resource = "tracks";
+  constructor(http: IHttpClient) {
+    super(http, TrackService.resource);
+  }
 
+  /**
+   * GET /api/tracks/:slug
+   */
+  getBySlug(slug: string): Promise<Track> {
+    return this.http.get(`/api/${TrackService.resource}/${slug}`);
+  }
+
+  /**
+   * GET /tracks (paginated)
+   */
   fetchTracks(
-    page: number = 1,
-    limit: number = 10,
-    sort?: keyof Track,
-    order?: "asc" | "desc",
-    genre?: string,
-    artist?: string,
-    search?: string
-  ): Promise<{ data: Track[]; meta: Meta }> {
-    return this.http.get<{ data: Track[]; meta: Meta }>("/api/tracks", {
-      params: { page, limit, sort, order, genre, artist, search },
+    opts: FetchTracksOptions = {},
+    signal?: AbortSignal
+  ): Promise<Paginated<Track>> {
+    const { page = 1, limit = 10, ...filters } = opts;
+    return this.http.get(`/api/${TrackService.resource}`, {
+      params: { page, limit, ...filters },
+      signal,
     });
   }
 
-  getTrackById(id: string): Promise<Track> {
-    return this.http.get<Track>(`/api/tracks/${id}`);
-  }
-
-  createTrack(dto: TrackFormData): Promise<Track> {
-    return this.http.post<Track>("/api/tracks", dto);
-  }
-
-  updateTrack(id: string, dto: TrackFormData): Promise<Track> {
-    return this.http.put<Track>(`/api/tracks/${id}`, dto);
-  }
-
-  deleteTrack(id: string): Promise<void> {
-    return this.http.delete<void>(`/api/tracks/${id}`);
-  }
-
+  /**
+   * POST /tracks/:id/upload
+   */
   uploadTrackFile(id: string, file: File): Promise<Track> {
     const form = new FormData();
     form.append("file", file);
-    return this.http.post<Track>(`/api/tracks/${id}/upload`, form, {
+    return this.http.post(`/api/${TrackService.resource}/${id}/upload`, form, {
       headers: { "Content-Type": "multipart/form-data" },
     });
   }
 
+  /**
+   * DELETE /tracks/:id/file (404-safe)
+   */
   async deleteTrackFile(id: string): Promise<Track> {
     try {
-      return await this.http.delete<Track>(`/api/tracks/${id}/file`);
+      return await this.http.delete(`/api/${TrackService.resource}/${id}/file`);
     } catch (err: any) {
       if (err.response?.status === 404) {
-        const track = await this.http.get<Track>(`/api/tracks/${id}`);
-        const { audioFile, ...rest } = track;
-        return rest as Track;
+        const { audioFile, ...track } = await this.getById(id);
+        return track as Track;
       }
       throw err;
     }
   }
 
+  /**
+   * POST /tracks/delete
+   */
   deleteMultipleTracks(
     ids: string[]
   ): Promise<{ success: string[]; failed: string[] }> {
-    return this.http.post<{ success: string[]; failed: string[] }>(
-      "/api/tracks/delete",
-      { ids }
-    );
+    return this.http.post(`/api/${TrackService.resource}/delete`, { ids });
   }
 }

--- a/client/src/components/TrackForm/index.tsx
+++ b/client/src/components/TrackForm/index.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from "react";
 import { TagSelector } from "@/components";
 import { Track, TrackFormData } from "@/types";
+import { useGenres } from "@/hooks";
 
 export function TrackForm({
   initialData,
@@ -11,6 +12,12 @@ export function TrackForm({
   onSubmit(data: TrackFormData): Promise<void>;
   onCancel(): void;
 }) {
+  const {
+    genres: genreList,
+    loading: genresLoading,
+    error: genresError,
+  } = useGenres();
+
   const [form, setForm] = useState<TrackFormData>({
     title: initialData?.title || "",
     artist: initialData?.artist || "",
@@ -114,6 +121,9 @@ export function TrackForm({
         <div data-testid="genre-selector">
           <TagSelector
             value={form.genres}
+            options={genreList}
+            loading={genresLoading}
+            error={!!genresError}
             onChange={(genres) => setForm({ ...form, genres })}
           />
         </div>

--- a/client/src/components/TrackTable/index.tsx
+++ b/client/src/components/TrackTable/index.tsx
@@ -18,6 +18,10 @@ interface Props {
   data: Track[];
   genres: string[];
   artists: string[];
+  genresLoading?: boolean;
+  artistsLoading?: boolean;
+  genresError?: boolean;
+  artistsError?: boolean;
   page: number;
   totalPages: number;
   limit: number;
@@ -44,6 +48,10 @@ export const TrackTable: React.FC<Props> = ({
   data,
   genres,
   artists,
+  genresLoading,
+  artistsLoading,
+  genresError,
+  artistsError,
   page,
   totalPages,
   limit,
@@ -150,6 +158,8 @@ export const TrackTable: React.FC<Props> = ({
             label="Artists"
             options={artists}
             value={filterArtist}
+            loading={artistsLoading}
+            error={artistsError}
             dataTestId="filter-artist"
             onChange={onFilterArtistChange}
           />
@@ -157,6 +167,8 @@ export const TrackTable: React.FC<Props> = ({
             label="Genres"
             options={genres}
             value={filterGenre}
+            loading={genresLoading}
+            error={genresError}
             dataTestId="filter-genre"
             onChange={onFilterGenreChange}
           />

--- a/client/src/components/common/FilterSelect/index.tsx
+++ b/client/src/components/common/FilterSelect/index.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 
-type NativeSelectProps = Omit<
+type NativeProps = Omit<
   React.SelectHTMLAttributes<HTMLSelectElement>,
-  "onChange" | "value"
+  "value" | "onChange"
 >;
 
-interface FilterSelectProps extends NativeSelectProps {
+interface FilterSelectProps extends NativeProps {
   label: string;
   options: string[];
   value: string;
-  onChange(value: string): void;
+  onChange(v: string): void;
+  loading?: boolean;
+  error?: boolean;
   dataTestId?: string;
 }
 
@@ -18,6 +20,8 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
   options,
   value,
   onChange,
+  loading = false,
+  error = false,
   dataTestId,
   ...nativeProps
 }) => (
@@ -25,19 +29,27 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
     <label className="label">
       <span className="label-text">{label}</span>
     </label>
+
     <select
       {...nativeProps}
       data-testid={dataTestId}
-      className="select select-bordered select-sm"
+      className="select select-bordered select-sm min-w-[8rem]"
       value={value}
+      disabled={loading || error}
       onChange={(e) => onChange(e.target.value)}
     >
-      <option value="">All {label.toLowerCase()}</option>
-      {options.map((opt) => (
-        <option key={opt} value={opt}>
-          {opt}
-        </option>
-      ))}
+      {loading && <option>Loading…</option>}
+      {error && <option>Error</option>}
+      {!loading && !error && (
+        <>
+          <option value="">All {label.toLowerCase()}</option>
+          {options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </>
+      )}
     </select>
   </div>
 );

--- a/client/src/components/common/TagSelector/index.tsx
+++ b/client/src/components/common/TagSelector/index.tsx
@@ -1,32 +1,37 @@
 import React, { useCallback } from "react";
-import { useGenres } from "@/hooks";
 import { TagBadge } from "./TagBadge";
 
 interface TagSelectorProps {
   value: string[];
+  options: string[];
+  loading?: boolean;
+  error?: boolean;
   onChange(tags: string[]): void;
 }
 
-export function TagSelector({ value, onChange }: TagSelectorProps) {
-  const genres = useGenres();
+export function TagSelector({
+  value,
+  options,
+  loading = false,
+  error = false,
+  onChange,
+}: TagSelectorProps) {
+  const available = options.filter((g) => !value.includes(g));
+  const isSelectDisabled = loading || error || available.length === 0;
 
   const handleAdd = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const genre = e.target.value;
-      if (genre && !value.includes(genre)) {
-        onChange([...value, genre]);
-      }
+      const g = e.target.value;
+      if (g && !value.includes(g)) onChange([...value, g]);
       e.target.value = "";
     },
     [value, onChange]
   );
 
   const handleRemove = useCallback(
-    (genre: string) => onChange(value.filter((g) => g !== genre)),
+    (g: string) => onChange(value.filter((v) => v !== g)),
     [value, onChange]
   );
-
-  const available = genres.filter((g) => !value.includes(g));
 
   return (
     <div className="flex flex-wrap gap-2 items-center">
@@ -35,20 +40,26 @@ export function TagSelector({ value, onChange }: TagSelectorProps) {
       ))}
 
       <select
-        className="select select-bordered select-sm w-auto min-w-max max-w-xs"
+        className="select select-bordered select-sm w-auto min-w-[8rem]"
         value=""
         onChange={handleAdd}
-        disabled={available.length === 0}
-        aria-disabled={available.length === 0}
+        disabled={isSelectDisabled}
+        aria-disabled={isSelectDisabled}
       >
-        <option value="" disabled>
-          + Add genre
-        </option>
-        {available.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt}
-          </option>
-        ))}
+        {loading && <option>Loading…</option>}
+        {error && <option>Error</option>}
+        {!loading && !error && (
+          <>
+            <option value="" disabled>
+              + Add genre
+            </option>
+            {available.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </>
+        )}
       </select>
     </div>
   );

--- a/client/src/helpers/index.ts
+++ b/client/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export { getValidClassNames } from "./getValidClassNames";
 export { extractErrorMessage } from "./extractErrorMessage";
+export { showToastMessage } from "./showToastMessage";

--- a/client/src/helpers/showToastMessage/index.tsx
+++ b/client/src/helpers/showToastMessage/index.tsx
@@ -1,0 +1,9 @@
+import { toast } from "react-toastify";
+import React from "react";
+
+export function showToastMessage(
+  type: "success" | "error",
+  msg: React.ReactNode
+) {
+  toast(<span data-testid={`toast-${type}`}>{msg}</span>, { type });
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,1 +1,2 @@
 export type { Track, TrackFormData, Meta } from "./track";
+export type { ListParams, Paginated } from "./pagination";

--- a/client/src/types/pagination.ts
+++ b/client/src/types/pagination.ts
@@ -1,0 +1,5 @@
+import { Meta } from "@/types";
+
+export type ListParams = Record<string, unknown>;
+
+export type Paginated<T, M = Meta> = { data: T[]; meta: M };

--- a/client/src/types/track.ts
+++ b/client/src/types/track.ts
@@ -1,5 +1,6 @@
 export interface Track {
   id: string;
+  slug: string;
   title: string;
   artist: string;
   album?: string;
@@ -9,7 +10,7 @@ export interface Track {
   audioFile?: string;
 }
 
-export type TrackFormData = Omit<Track, "id" | "createdAt">;
+export type TrackFormData = Omit<Track, "id" | "slug" | "createdAt">;
 
 export interface Meta {
   total: number;

--- a/src/controllers/artists.controller.ts
+++ b/src/controllers/artists.controller.ts
@@ -1,0 +1,15 @@
+import { getArtists } from "../utils/db";
+import { RouteHandler } from "../types";
+
+/**
+ * Get all artists (distinct)
+ */
+export const getAllArtists: RouteHandler<{}> = async (request, reply) => {
+  try {
+    const artists = await getArtists();
+    return reply.code(200).send(artists);
+  } catch (error) {
+    request.log.error(error);
+    return reply.code(500).send({ error: "Internal Server Error" });
+  }
+};

--- a/src/controllers/tracks.controller.ts
+++ b/src/controllers/tracks.controller.ts
@@ -8,7 +8,6 @@ import {
   deleteMultipleTracks,
   saveAudioFile,
   deleteAudioFile,
-  getArtists,
 } from "../utils/db";
 import { createSlug } from "../utils/slug";
 import {
@@ -51,19 +50,6 @@ export const getAllTracks: RouteHandler<ListTracksQuery> = async (
     };
 
     return reply.code(200).send(response);
-  } catch (error) {
-    request.log.error(error);
-    return reply.code(500).send({ error: "Internal Server Error" });
-  }
-};
-
-/**
- * Get all artists (distinct)
- */
-export const getAllArtists: RouteHandler<{}> = async (request, reply) => {
-  try {
-    const artists = await getArtists();
-    return reply.code(200).send(artists);
   } catch (error) {
     request.log.error(error);
     return reply.code(500).send({ error: "Internal Server Error" });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,7 +2,6 @@ import { FastifyInstance } from "fastify";
 import {
   addTrack,
   deleteTrackFile,
-  getAllArtists,
   getAllTracks,
   getTrack,
   removeTrack,
@@ -10,6 +9,7 @@ import {
   updateTrackById,
   uploadTrackFile,
 } from "./controllers/tracks.controller";
+import { getAllArtists } from "./controllers/artists.controller";
 import { getAllGenres } from "./controllers/genres.controller";
 
 export default async function routes(fastify: FastifyInstance) {


### PR DESCRIPTION
types
- add ListParams & Paginated<T>; extend Track with slug;

api layer
- introduce BaseService for CRUD;
- convert Artist & Genre services to one-liner subclasses;
- rebuild TrackService (option bag, AbortSignal, upload / bulk);

hooks
- useTracks, useGenres, useArtists now expose {data, loading, error} and handle cancellation;

components
- FilterSelect & TagSelector show “Loading…” / “Error” states and keep min-width;
- TrackTable & TracksPage wired to new props + refetch logic;

backend
- extract /api/artists to artists.controller.ts; update route registration.