### PR TITLE
refactor(TrackTable): reduce props

### DIFF
--- a/client/src/components/TrackToolbar/index.tsx
+++ b/client/src/components/TrackToolbar/index.tsx
@@ -1,0 +1,58 @@
+// client/src/components/TracksToolbar/index.tsx
+import React from "react";
+import { FilterSelect, SearchInput } from "@/components";
+
+export interface TrackToolbarProps {
+  artists: { list: string[]; loading: boolean; error: boolean };
+  genres: { list: string[]; loading: boolean; error: boolean };
+
+  filterArtist: string;
+  setFilterArtist(v: string): void;
+
+  filterGenre: string;
+  setFilterGenre(v: string): void;
+
+  search: string;
+  setSearch(v: string): void;
+}
+
+export const TrackToolbar: React.FC<TrackToolbarProps> = ({
+  artists,
+  genres,
+  filterArtist,
+  setFilterArtist,
+  filterGenre,
+  setFilterGenre,
+  search,
+  setSearch,
+}) => (
+  <div className="flex items-center justify-between mb-4">
+    <SearchInput
+      value={search}
+      onChange={setSearch}
+      placeholder="Search tracks…"
+      dataTestId="search-input"
+    />
+
+    <div className="flex gap-4">
+      <FilterSelect
+        label="Artists"
+        options={artists.list}
+        value={filterArtist}
+        loading={artists.loading}
+        error={artists.error}
+        dataTestId="filter-artist"
+        onChange={setFilterArtist}
+      />
+      <FilterSelect
+        label="Genres"
+        options={genres.list}
+        value={filterGenre}
+        loading={genres.loading}
+        error={genres.error}
+        dataTestId="filter-genre"
+        onChange={setFilterGenre}
+      />
+    </div>
+  </div>
+);

--- a/client/src/components/common/SelectModeToggle/index.tsx
+++ b/client/src/components/common/SelectModeToggle/index.tsx
@@ -15,26 +15,29 @@ export const SelectModeToggle: React.FC<SelectModeToggleProps> = ({
   onBulkDelete,
   bulkDeleteDisabled,
 }) => (
-  <fieldset className="fieldset">
-    <legend className="fieldset-legend text-sm">Multi-Delete Mode</legend>
-    <div className="flex gap-2">
+  <div
+    role="toolbar"
+    aria-label="Selection mode controls"
+    className="flex items-center space-x-2 ml-auto"
+  >
+    <button
+      aria-pressed={selectionMode}
+      onClick={onToggleMode}
+      className="btn btn-primary btn-sm"
+      data-testid="select-mode-toggle"
+    >
+      {selectionMode ? "Exit Select" : "Multi Select"}
+    </button>
+
+    {selectionMode && (
       <button
-        className="btn btn-sm"
-        data-testid="select-mode-toggle"
-        onClick={onToggleMode}
+        onClick={onBulkDelete}
+        disabled={bulkDeleteDisabled}
+        className="btn btn-sm btn-error"
+        data-testid="bulk-delete-button"
       >
-        {selectionMode ? "Exit Select" : "Select"}
+        Delete {selectedCount}
       </button>
-      {selectionMode && (
-        <button
-          className="btn btn-sm btn-error"
-          data-testid="bulk-delete-button"
-          disabled={bulkDeleteDisabled}
-          onClick={onBulkDelete}
-        >
-          Delete {selectedCount}
-        </button>
-      )}
-    </div>
-  </fieldset>
+    )}
+  </div>
 );

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -3,6 +3,7 @@ export { DeleteConfirmationModal } from "./Modal/DeleteConfirmationModal";
 export { UploadFileModal } from "./Modal/UploadFileModal";
 export { TrackForm } from "./TrackForm";
 export { TrackTable } from "./TrackTable";
+export { TrackToolbar } from "./TrackToolbar";
 export {
   Logo,
   FilterSelect,

--- a/client/src/pages/TracksPage/index.tsx
+++ b/client/src/pages/TracksPage/index.tsx
@@ -6,6 +6,7 @@ import {
   TrackForm,
   TrackTable,
   UploadFileModal,
+  TrackToolbar,
 } from "@/components";
 import type { Track, TrackFormData } from "@/types";
 import { trackService } from "@/api";
@@ -136,6 +137,18 @@ const TracksPage: React.FC = () => {
     }
   };
 
+  const openEdit = (id: string) =>
+    setEditingTrack(data.find((t) => t.id === id) ?? null);
+
+  const openDelete = (id: string) =>
+    setDeletingTrack(data.find((t) => t.id === id) ?? null);
+
+  const openUpload = (id: string) =>
+    setUploadingTrack(data.find((t) => t.id === id) ?? null);
+
+  const openDeleteFile = (id: string) =>
+    setDeletingFile(data.find((t) => t.id === id) ?? null);
+
   return (
     <div className="min-h-screen">
       <div className="container mx-auto px-4 py-6">
@@ -150,41 +163,40 @@ const TracksPage: React.FC = () => {
           </button>
         </div>
 
+        <TrackToolbar
+          artists={{
+            list: artistList,
+            loading: artistsLoading,
+            error: !!artistsError,
+          }}
+          genres={{
+            list: genreList,
+            loading: genresLoading,
+            error: !!genresError,
+          }}
+          filterArtist={filterArtist}
+          setFilterArtist={setFilterArtist}
+          filterGenre={filterGenre}
+          setFilterGenre={setFilterGenre}
+          search={search}
+          setSearch={setSearch}
+        />
+
         <TrackTable
           data={data}
-          genres={genreList}
-          artists={artistList}
-          genresLoading={genresLoading}
-          genresError={!!genresError}
-          artistsLoading={artistsLoading}
-          artistsError={!!artistsError}
+          sort={sort}
+          order={order}
+          setSort={setSort}
+          setOrder={setOrder}
           page={page}
           totalPages={totalPages}
           limit={limit}
           setPage={setPage}
           setLimit={setLimit}
-          sort={sort}
-          order={order}
-          setSort={setSort}
-          setOrder={setOrder}
-          filterGenre={filterGenre}
-          onFilterGenreChange={setFilterGenre}
-          filterArtist={filterArtist}
-          onFilterArtistChange={setFilterArtist}
-          search={search}
-          onSearchChange={setSearch}
-          onEdit={(id) =>
-            setEditingTrack(data.find((t) => t.id === id) ?? null)
-          }
-          onDelete={(id) =>
-            setDeletingTrack(data.find((t) => t.id === id) ?? null)
-          }
-          onUploadClick={(id) =>
-            setUploadingTrack(data.find((t) => t.id === id) ?? null)
-          }
-          onDeleteFile={(id) =>
-            setDeletingFile(data.find((t) => t.id === id) ?? null)
-          }
+          onEdit={openEdit}
+          onDelete={openDelete}
+          onUploadClick={openUpload}
+          onDeleteFile={openDeleteFile}
           onBulkDelete={setBulkDeleteIds}
         />
 


### PR DESCRIPTION
- refactor TrackTable to only accept data, sorting, pagination, and action handlers: remove all filtering and search props so the table stays focused on rendering rows;
- extract search and filter controls into a new TrackToolbar component: it will render the search input plus artist and genre selects with loading and error states;
- update TracksPage to render TrackToolbar above the table;
- replace the <fieldset> in SelectModeToggle with a <div role="toolbar" aria-label="Selection mode controls">.