### PR TITLE
feat(TrackTable): stabilize row keys & pass full Track object

### DIFF
--- a/client/src/components/TrackTable/columns.tsx
+++ b/client/src/components/TrackTable/columns.tsx
@@ -12,10 +12,10 @@ export interface SelectionOptions {
 }
 
 export const getColumns = (
-  onEdit: (id: string) => void,
-  onDelete: (id: string) => void,
-  onUploadClick: (id: string) => void,
-  onDeleteFile: (id: string) => void,
+  onEdit: (track: Track) => void,
+  onDelete: (track: Track) => void,
+  onUploadClick: (track: Track) => void,
+  onDeleteFile: (track: Track) => void,
   selectionOptions?: SelectionOptions
 ): ColumnDef<Track>[] => {
   const base: ColumnDef<Track>[] = [
@@ -87,18 +87,19 @@ export const getColumns = (
       enableSorting: false,
       size: 300,
       cell: ({ row }) => {
-        const { id, audioFile } = row.original;
-        return audioFile ? (
+        const track = row.original;
+
+        return track.audioFile ? (
           <AudioPlayer
-            src={`/api/files/${audioFile}`}
-            id={id}
-            onRemove={() => onDeleteFile(id)}
+            src={`/api/files/${track.audioFile}`}
+            id={track.id}
+            onRemove={() => onDeleteFile(track)}
           />
         ) : (
           <button
             className="btn btn-xs"
-            onClick={() => onUploadClick(id)}
-            data-testid={`upload-track-${id}`}
+            onClick={() => onUploadClick(track)}
+            data-testid={`upload-track-${track.id}`}
           >
             Upload
           </button>
@@ -111,20 +112,21 @@ export const getColumns = (
       header: "Actions",
       size: 50,
       cell: ({ row }) => {
-        const id = row.original.id;
+        const track = row.original;
+
         return (
           <div className="flex gap-2">
             <button
               className="btn btn-xs btn-ghost"
-              onClick={() => onEdit(id)}
-              data-testid={`edit-track-${id}`}
+              onClick={() => onEdit(track)}
+              data-testid={`edit-track-${track.id}`}
             >
               <Edit2 size={14} />
             </button>
             <button
               className="btn btn-xs btn-error btn-outline"
-              onClick={() => onDelete(id)}
-              data-testid={`delete-track-${id}`}
+              onClick={() => onDelete(track)}
+              data-testid={`delete-track-${track.id}`}
             >
               <Trash2 size={14} />
             </button>

--- a/client/src/components/TrackTable/index.tsx
+++ b/client/src/components/TrackTable/index.tsx
@@ -23,10 +23,10 @@ export interface TrackTableProps {
   limit: number;
   setPage(p: number): void;
   setLimit(l: number): void;
-  onEdit(id: string): void;
-  onDelete(id: string): void;
-  onUploadClick(id: string): void;
-  onDeleteFile(id: string): void;
+  onEdit(track: Track): void;
+  onDelete(track: Track): void;
+  onUploadClick(track: Track): void;
+  onDeleteFile(track: Track): void;
   onBulkDelete(ids: string[]): void;
 }
 
@@ -91,6 +91,7 @@ export const TrackTable: React.FC<TrackTableProps> = ({
   const table = useReactTable({
     data,
     columns,
+    getRowId: (row) => row.id,
     state: { sorting },
     onSortingChange: setSorting,
     manualSorting: sorting[0]?.id !== "genres",

--- a/client/src/pages/TracksPage/index.tsx
+++ b/client/src/pages/TracksPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTracks, useArtists, useGenres } from "@/hooks";
 import {
   DeleteConfirmationModal,
@@ -152,31 +152,6 @@ const TracksPage: React.FC = () => {
     }
   };
 
-  const openEdit = useCallback(
-    (id: string) => setEditingTrack(data.find((t) => t.id === id) ?? null),
-    [data]
-  );
-
-  const openDelete = useCallback(
-    (id: string) => setDeletingTrack(data.find((t) => t.id === id) ?? null),
-    [data]
-  );
-
-  const openUpload = useCallback(
-    (id: string) => setUploadingTrack(data.find((t) => t.id === id) ?? null),
-    [data]
-  );
-
-  const openDeleteFile = useCallback(
-    (id: string) => setDeletingFile(data.find((t) => t.id === id) ?? null),
-    [data]
-  );
-
-  const triggerBulkDelete = useCallback(
-    (ids: string[]) => setBulkDeleteIds(ids),
-    []
-  );
-
   return (
     <div className="min-h-screen">
       <div className="container mx-auto px-4 py-6">
@@ -221,11 +196,11 @@ const TracksPage: React.FC = () => {
           limit={limit}
           setPage={setPage}
           setLimit={setLimit}
-          onEdit={openEdit}
-          onDelete={openDelete}
-          onUploadClick={openUpload}
-          onDeleteFile={openDeleteFile}
-          onBulkDelete={triggerBulkDelete}
+          onEdit={setEditingTrack}
+          onDelete={setDeletingTrack}
+          onUploadClick={setUploadingTrack}
+          onDeleteFile={setDeletingFile}
+          onBulkDelete={setBulkDeleteIds}
         />
 
         {isCreating && (


### PR DESCRIPTION
Prevent remount:

- in TrackTable add `getRowId: row => row.id` to the useReactTable config, so React no longer uses index-based keys (fixes row remount on create).

Pass full Track:

- change getColumns() and <TrackTable> prop types from (id: string) => void to (track: Track) => void;
- in each cell (onEdit, onDelete, onUploadClick, onDeleteFile), call the handler with row.original instead of row.original.id;

Clean up lookups:

- in TracksPage, remove the four openEdit(id), openDelete(id), etc. callbacks and their Array.find() calls;
- call setEditingTrack(track), setDeletingTrack(track), etc., directly in the table handlers.